### PR TITLE
Fix docker path on MacOS

### DIFF
--- a/src/pythainer/builders/__init__.py
+++ b/src/pythainer/builders/__init__.py
@@ -7,6 +7,7 @@ handling commands like package installation, environment variable setting, and u
 tailored specifically for Docker environments.
 """
 import os
+import subprocess
 import tempfile
 from pathlib import Path
 from typing import Dict, List
@@ -262,7 +263,7 @@ class DockerBuilder(PartialDockerBuilder):
 
         all_dockerfile_paths = dockerfile_paths + [
             "/tmp/Dockerfile",
-            "/tmp/benchkit/docker/latest/Dockerfile",
+            "/tmp/pythainer/docker/latest/Dockerfile",
         ]
 
         for dockerfile_path in all_dockerfile_paths:
@@ -305,9 +306,15 @@ class DockerBuilder(PartialDockerBuilder):
         if gid is not None:
             build_args.append(f"--build-arg=GID={gid}")
 
+
+        try:
+            docker_path = subprocess.check_output(["which", "docker"], text=True).strip()
+        except subprocess.CalledProcessError:
+            print("Docker not found")
+
         command = (
             [
-                "docker",
+                docker_path,
                 "build",
                 "--file",
                 f"{dockerfile_path}",
@@ -323,7 +330,7 @@ class DockerBuilder(PartialDockerBuilder):
 
     def generate_build_script(
         self,
-        output_path: PathType = "/tmp/benchkit/docker/latest/docker-build.sh",
+        output_path: PathType = "/tmp/pythainer/docker/latest/docker-build.sh",
     ) -> None:
         """
         Generates a shell script to execute the Docker build commands.
@@ -371,10 +378,10 @@ class DockerBuilder(PartialDockerBuilder):
         Parameters:
             dockerfile_savepath (PathType): Optional path to save the Dockerfile used for the build.
         """
-        main_dir = Path("/tmp/benchkit/docker/")
+        main_dir = Path("/tmp/pythainer/docker/")
         mkdir(main_dir)
         with tempfile.TemporaryDirectory(
-            prefix="/tmp/benchkit/docker/docker-build-",
+            prefix="/tmp/pythainer/docker/docker-build-",
             dir=main_dir,
         ) as temp_dir:
             temp_path = Path(temp_dir)
@@ -392,7 +399,7 @@ class DockerBuilder(PartialDockerBuilder):
             )
 
             environment = self.get_build_environment()
-
+            
             shell_out(
                 command=command,
                 current_dir=temp_path,
@@ -563,7 +570,7 @@ class DockerfileDockerBuilder(DockerBuilder):
 
     def generate_build_script(
         self,
-        output_path: PathType = "/tmp/benchkit/docker/latest/docker-build.sh",
+        output_path: PathType = "/tmp/pythainer/docker/latest/docker-build.sh",
     ) -> None:
         raise NotImplementedError()
 

--- a/src/pythainer/runners/__init__.py
+++ b/src/pythainer/runners/__init__.py
@@ -261,7 +261,7 @@ class ConcreteDockerRunner(DockerRunner):
 
     def generate_script(
         self,
-        output_path: PathType = "/tmp/benchkit/docker/latest/docker-run.sh",
+        output_path: PathType = "/tmp/pythainer/docker/latest/docker-run.sh",
     ):
         """
         Generates a script file to run the Docker container with the current configuration.


### PR DESCRIPTION
When using the module on macos, the docker executable wasn't found, resulting in a crash of the program.
I used the subprocess module to get the result of the shell command `where docker` and use the result as path for builder.

I also renamed the folder "benchkit" in `/tmp` with "pythainer", I can undo that if needed.
 
- Tested on MacOS and Ubuntu 22.04.