### PR TITLE
Run commands before entering the interactive docker

### DIFF
--- a/src/pythainer/runners/__init__.py
+++ b/src/pythainer/runners/__init__.py
@@ -229,7 +229,10 @@ class ConcreteDockerRunner(DockerRunner):
         result = " ".join(cmd)
         return result
 
-    def run(self, commands: list[str] | None = None,) -> None:
+    def run(
+        self,
+        commands: list[str] | None = None,
+    ) -> None:
         """
         Executes the constructed Docker command.
 


### PR DESCRIPTION
The method `run` of `DockerRunner` now takes a list of commands that will be executed before entering into the interactive docker.

**Example**: If you want to reload `.bashrc` before entering into the interactive mode, you can start the runner with `docker_runner.run(commands=["source  ~/.bashrc"])`