### PR TITLE
Add ruff and mypy to linting and checks

### DIFF
--- a/.github/workflows/codefmt.yml
+++ b/.github/workflows/codefmt.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install dependencies from requirements.txt
       run: |
         python3 -m pip install --upgrade pip
-        pip3 install $(grep -E '^(black|isort|flake8|pylint|pytest)' requirements.txt)
+        pip3 install $(grep -E '^(black|isort|flake8|pylint|pytest|ruff|mypy|types-click)' requirements.txt)
 
     - name: Show versions of tools
       run: |
@@ -27,10 +27,12 @@ jobs:
         echo "isort $(isort --version-number)"
         flake8 --version
         pylint --version
+        ruff --version
+        mypy --version
 
     - name: Run isort (check only)
       run: |
-        isort --check-only --profile=black src/ tests/ scripts/
+        isort --check-only --profile=black src/ tests/ examples/ scripts/
 
     - name: Run Black (check only)
       run: |
@@ -38,11 +40,20 @@ jobs:
 
     - name: Run Flake8
       run: |
-        flake8 src/ tests/
+        flake8 src/ tests/ examples/
 
     - name: Run pylint
       run: |
-        pylint src/ tests/
+        pylint src/ tests/ examples/
+
+    - name: Run ruff
+      run: |
+        ruff check .
+
+# TODO enable when ready:
+#    - name: Run mypy
+#      run: |
+#        mypy .
 
     - name: Check copyright
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,39 @@ skip = [
     "venv"
 ]
 skip_glob = ["**/venv/**/*"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+# E/W = pycodestyle (incl. trailing whitespace W291/W293)
+# F   = pyflakes
+# I   = import sorting (isort)
+# B   = bugbear
+# UP  = pyupgrade
+# SIM = simplify
+# C4  = comprehensions
+# RET = return-related
+# A   = builtins shadowing
+# TID = tidy-imports
+# ERA = commented-out code
+# S   = security (bandit)
+# TODO enable the following when ready
+# select = ["E", "W", "F", "I", "B", "UP", "SIM", "C4", "RET", "A", "TID", "ERA", "S"]
+
+[tool.ruff.lint.per-file-ignores]
+# Tests often use assert and subprocess; relax noisy bandit checks here.
+# TODO enable the following when ready
+# "tests/**" = ["S101", "S603", "S607"]
+
+[tool.mypy]
+python_version = "3.10"
+packages = ["pythainer"]
+# TODO enable the following when ready
+#disallow_untyped_defs = true
+#no_implicit_optional = true
+#warn_return_any = true
+#warn_unused_ignores = true
+#strict_equality = true
+#pretty = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ isort<=6.0.1
 pycodestyle<=2.14.0
 pylint<=3.3.7
 pytest<=8.4.2
+ruff<=0.13.0
+mypy<=1.18.1

--- a/scripts/all_checks.sh
+++ b/scripts/all_checks.sh
@@ -19,19 +19,27 @@ venv_dir=$(readlink -f "${pythainer_root_dir}/venv")
   flake8=$(readlink -f "${venv_dir}/bin/flake8")
   isort=$(readlink -f "${venv_dir}/bin/isort")
   black=$(readlink -f "${venv_dir}/bin/black")
+  ruff=$(readlink -f "${venv_dir}/bin/ruff")
+  mypy=$(readlink -f "${venv_dir}/bin/mypy")
 
   echo "-- check copyright. --"
   ./scripts/list_missing_copyright.sh
 
   echo "-- running pylint. --"
-  ${pylint} src/ tests/ || true
+  ${pylint} src/ tests/ examples/ || true
 
   echo "-- running flake8. --"
-  ${flake8} src/ tests/ || true
+  ${flake8} src/ tests/ examples/ || true
 
   echo "-- running isort. --"
-  ${isort} --profile=black src/ tests/
+  ${isort} --profile=black src/ tests/ examples/
 
   echo "-- running black. --"
   ${black} -l 100 .
+
+  echo "-- running ruff. --"
+  ${ruff} check .
+
+  echo "-- running mypy. --"
+  ${mypy} .
 )


### PR DESCRIPTION
This change extends the linting setup by introducing ruff and mypy to the GitHub Actions workflow, local all_checks.sh script, and project configuration. The flake8, pylint, and isort checks are also expanded to include the examples/ directory. Corresponding configuration blocks for ruff and mypy are added in pyproject.toml, and requirements.txt is updated to include both tools.

Mypy and advanced ruff configuration are currently disabled while we adapt the codebase to comply with them.