### PR TITLE
Add CI workflow for unit and integration tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,72 @@
+name: pythainer tests
+
+on:
+  push:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit:
+    name: Unit (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            pip-${{ runner.os }}-${{ matrix.python-version }}-
+
+      - name: Install package + test deps
+        run: |
+          python -m pip install --upgrade pip
+          # if you defined extras in pyproject:
+          pip install -e .
+          pip install -e ".[test]"
+          # fallback (if no extras):
+          # pip install pytest pytest-cov
+
+      - name: Run unit tests + coverage
+        run: |
+          pytest -q --cov=pythainer --cov-report=term-missing -m "not integration"
+
+  integration:
+    name: Integration (Docker)
+    needs: unit
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install package + test deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install ".[test]"
+
+      - name: Docker info
+        run: docker info
+
+      - name: Run integration tests
+        env:
+          PYTHAINER_INTEGRATION: "1"
+        run: |
+          pytest -q -m integration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,9 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "click>=8.2.1"
+    "black<=25.1.0",
+    "click<=8.2.1",
+    "isort<=6.0.1",
 ]
 
 [project.urls]
@@ -22,6 +24,17 @@ Issues = "https://github.com/apaolillo/pythainer/issues"
 
 [project.scripts]
 pythainer = "pythainer.cli:main"
+
+[project.optional-dependencies]
+test = [
+  "pytest>=8",
+  "pytest-cov>=4",
+]
+dev = [
+  "ruff<=0.13.0",
+  "mypy<=1.18.1",
+  "types-click<=7.1.8",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pylint<=3.3.7
 pytest<=8.4.2
 ruff<=0.13.0
 mypy<=1.18.1
+types-click<=7.1.8


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow that runs unit tests across Python 3.10, 3.11, and 3.12, and adds a separate job for Docker-based integration tests. The workflow includes caching of pip dependencies, installation of test extras, and coverage reporting for unit tests. Integration tests are run with a dedicated environment variable to distinguish them.

In addition, optional dependencies for test and dev are added to pyproject.toml, including pytest, pytest-cov, ruff, mypy, and types-click. The requirements file is updated accordingly to keep local and CI environments aligned.