### PR TITLE
Deduplicate apt packages and clean up internals

### DIFF
--- a/src/pythainer/builders/cmds.py
+++ b/src/pythainer/builders/cmds.py
@@ -195,7 +195,7 @@ def _add_pkg_apt(packages: list[str]) -> str:
     Returns:
         str: A Dockerfile RUN command to update, install, and clean up apt packages.
     """
-    fmt_packages = "".join([f"        {p} \\\n" for p in sorted(packages)])
+    fmt_packages = "".join([f"        {p} \\\n" for p in sorted(set(packages))])
     cmd = (
         f"apt-get update && apt-get install -y --no-install-recommends \\\n{fmt_packages}"
         f"    && rm -rf /var/lib/apt/lists/*"

--- a/src/pythainer/runners/__init__.py
+++ b/src/pythainer/runners/__init__.py
@@ -153,12 +153,12 @@ class ConcreteDockerRunner(DockerRunner):
         self._tty = tty
         self._interactive = interactive
 
-        self._cached_command = None
+        self._cached_command: list[str] | None = None
 
     def __or__(self, other: DockerRunner) -> "ConcreteDockerRunner":
         if isinstance(other, ConcreteDockerRunner):
             return NotImplemented
-        abstract_runner = super().__or__(other=other)
+        abstract_runner = super().__or__(other)
         return abstract_runner.concretize(
             image=self._image,
             name=self._name,
@@ -253,8 +253,8 @@ class ConcreteDockerRunner(DockerRunner):
             command = command[:-1]
         if commands:
             commands_serial = " && ".join(commands)
-            commands_serial = ["bash", "-c", commands_serial]
-            command.extend(commands_serial)
+            commands_serial_lst = ["bash", "-c", commands_serial]
+            command.extend(commands_serial_lst)
         shell_out(
             command=command,
             output_is_log=True,


### PR DESCRIPTION
Wrap sorted() with set() in _add_pkg_apt so duplicate packages are eliminated before rendering the Dockerfile RUN command.

In ConcreteDockerRunner, add a type annotation to _cached_command, pass a positional arg in __or__ instead of a keyword, and rename the shadowed commands_serial variable in exec() to avoid reusing the same name for a different type.